### PR TITLE
fix: remove status code value check for apiexception

### DIFF
--- a/src/Altinn.Dan.Plugin.Banking/Services/BankService.cs
+++ b/src/Altinn.Dan.Plugin.Banking/Services/BankService.cs
@@ -126,11 +126,11 @@ public class BankService(
         }
         catch (Exception e)
         {
-            if (e is ApiException k && k.StatusCode >= 400)
+            if (e is ApiException k)
             {
                 var successfulTasks = accountsDetailsTasks.Where(x => x.IsCompletedSuccessfully).ToArray();
                 var successfulAccounts = await Task.WhenAll(successfulTasks);
-                var faultedAccounts = accounts.Accounts1.Where(x => !successfulAccounts.Any(y => y.Account!.AccountReference == x.AccountReference)).ToList();
+                var faultedAccounts = accounts.Accounts1.Where(x => successfulAccounts.All(y => y.Account!.AccountReference != x.AccountReference)).ToList();
 
                 foreach (var faultedAccount in faultedAccounts)
                 {
@@ -143,7 +143,7 @@ public class BankService(
             }
             else
             {
-                /* 
+                /*
                  * TODO:
                  * Will rethrow if a non-API exception is thrown.
                  */


### PR DESCRIPTION
### Description
Some accounts are returned as status code 206 partial, which is not handled properly by BankClient_v2, which yields an ApiException. This is okay, but we did only handle those which had statuscode >= 400, which 206 is not. We currently still want to treat them as HasError=true, so by removing the status code check and just do the same account handling for all ApiExceptions we throw handles it as we currently want.

### Documentation
- [ ] Doc updated
